### PR TITLE
updated requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
     install_requires=[
         'dataset >= 1.0.0',
         "PyYAML >= 3.10",
-        "six >= 1.7.3"
+        "six >= 1.7.3",
+        "normality >= 2.1.1",
     ] + py26_dependency,
     tests_require=[],
     test_suite='test',


### PR DESCRIPTION
Without this oackage running datafreeze fails:

```
% datafreeze
Traceback (most recent call last):
  File "/Users/me/project.venv/bin/datafreeze", line 5, in <module>
    from datafreeze.app import main
  File "/Users/me/project.venv/lib/python3.8/site-packages/datafreeze/__init__.py", line 1, in <module>
    from datafreeze.app import freeze
  File "/Users/me/project.venv/lib/python3.8/site-packages/datafreeze/app.py", line 8, in <module>
    from datafreeze.format import get_serializer
  File "/Users/me/project.venv/lib/python3.8/site-packages/datafreeze/format/__init__.py", line 1, in <module>
    from datafreeze.format.fjson import JSONSerializer
  File "/Users/me/project.venv/lib/python3.8/site-packages/datafreeze/format/fjson.py", line 8, in <module>
    from datafreeze.format.common import Serializer
  File "/Users/me/project.venv/lib/python3.8/site-packages/datafreeze/format/common.py", line 7, in <module>
    from normality import slugify
ModuleNotFoundError: No module named 'normality'

```